### PR TITLE
Allow customizing the protocol tag for each RoundTripper

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.1.1: Qmc6tqtdKn1fVCGmU2StfULdXb8xPxmGh19NsYsgVkqjbw
+1.1.2: QmXkLVayepHcdV46UUHEhVF4CapBWRRWVWvfjGJPrixrFC

--- a/p2phttp_test.go
+++ b/p2phttp_test.go
@@ -39,7 +39,7 @@ func TestServerClient(t *testing.T) {
 	srvHost.Peerstore().AddAddrs(clientHost.ID(), clientHost.Addrs(), peerstore.PermanentAddrTTL)
 	clientHost.Peerstore().AddAddrs(srvHost.ID(), srvHost.Addrs(), peerstore.PermanentAddrTTL)
 
-	listener, err := gostream.Listen(srvHost, P2PProtocol)
+	listener, err := gostream.Listen(srvHost, "/testiti-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestServerClient(t *testing.T) {
 	}()
 
 	tr := &http.Transport{}
-	tr.RegisterProtocol("libp2p", NewTransport(clientHost))
+	tr.RegisterProtocol("libp2p", NewTransport(clientHost, ProtocolOption("/testiti-test")))
 	client := &http.Client{Transport: tr}
 
 	buf := bytes.NewBufferString("Hector")

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "license": "MIT",
   "name": "go-libp2p-http",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.1.1"
+  "version": "1.1.2"
 }
 


### PR DESCRIPTION
This adds optional functional Options to the NewTransport method.

cc @lanzafame 